### PR TITLE
dpdk: upgrade to 18.11.7 lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,7 @@ RUN apt-get update \
     pkg-config \
     python \
     python-pip \
+    python-pyelftools \
     python-setuptools \
     tcpdump \
     wget \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ vagrant$ docker run -it --rm \
     --security-opt seccomp=unconfined \
     -v /lib/modules:/lib/modules \
     -v /dev/hugepages:/dev/hugepages \
-    getcapsule/sandbox:18.11.6-1.42 /bin/bash
+    getcapsule/sandbox:18.11.7-1.42 /bin/bash
 ```
 
 The sandbox must run in privileged mode with host networking, so it can access the two network interfaces on the Vagrant host dedicated to DPDK applications.
@@ -116,17 +116,17 @@ host$ exit
 Before your `Capsule` application can access a network interface on the host, the interface must be bound to a DPDK compatible driver with the [`dpdk-devbind`](https://doc.dpdk.org/guides/tools/devbind.html) utility. To bind the driver, find the interface's PCI address and use the command,
 
 ```
-host$ docker pull getcapsule/dpdk-devbind:18.11.6
+host$ docker pull getcapsule/dpdk-devbind:18.11.7
 host$ docker run --rm --privileged --network=host \
     -v /lib/modules:/lib/modules \
-    getcapsule/dpdk-devbind:18.11.6 \
+    getcapsule/dpdk-devbind:18.11.7 \
     /bin/bash -c 'dpdk-devbind.py --force -b uio_pci_generic #PCI_ADDR#'
 ```
 
 Once the necessary changes are made, pull down the sandbox container and run it,
 
 ```
-host$ docker pull getcapsule/sandbox:18.11.6-1.42
+host$ docker pull getcapsule/sandbox:18.11.7-1.42
 host$ docker run ...
 ```
 
@@ -161,7 +161,7 @@ host$ sudo insmod /lib/modules/`uname -r`/extra/dpdk/rte_kni.ko
 
 When packaging your application for release, the package must include the shared `DPDK` libraries and have as dependencies `libnuma` and `libpcap` for your Linux distribution.
 
-If you want to containerize your release, you can use [`getcapsule/dpdk:18.11.6`](https://hub.docker.com/repository/docker/getcapsule/dpdk) as the base image which includes `libnuma`, `libpcap` and `DPDK`. For other packaging methods, you can find the `DPDK` libraries in `/usr/local/lib/x86_64-linux-gnu`.
+If you want to containerize your release, you can use [`getcapsule/dpdk:18.11.7`](https://hub.docker.com/repository/docker/getcapsule/dpdk) as the base image which includes `libnuma`, `libpcap` and `DPDK`. For other packaging methods, you can find the `DPDK` libraries in `/usr/local/lib/x86_64-linux-gnu`.
 
 ## Contributing
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,9 +27,9 @@ VAGRANTFILE_API_VERSION = "2"
 end
 
 # Default Vagrant vars.
-$devbind_img = "getcapsule/dpdk-devbind:18.11.6"
-$dpdkmod_img = "getcapsule/dpdk-mod:18.11.6-`uname -r`"
-$sandbox_img = "getcapsule/sandbox:18.11.6-1.42"
+$devbind_img = "getcapsule/dpdk-devbind:18.11.7"
+$dpdkmod_img = "getcapsule/dpdk-mod:18.11.7-`uname -r`"
+$sandbox_img = "getcapsule/sandbox:18.11.7-1.42"
 
 $dpdk_driver = "uio_pci_generic"
 $dpdk_devices = "0000:00:08.0 0000:00:09.0"

--- a/docker.mk
+++ b/docker.mk
@@ -7,7 +7,7 @@ DPDK_DEVBIND_IMG = dpdk-devbind
 DPDK_MOD_IMG = dpdk-mod
 DPDK_MOD_KERNEL = $(shell uname -r)
 DPDK_TARGET = /usr/local/src/dpdk-$(DPDK_VERSION)
-DPDK_VERSION = 18.11.6
+DPDK_VERSION = 18.11.7
 
 RR_VERSION = 5.3.0
 RUST_BASE_IMG = rust:$(RUST_VERSION)-slim-buster

--- a/scripts/dpdk.sh
+++ b/scripts/dpdk.sh
@@ -18,7 +18,7 @@
 #
 
 ## Version we recommend.
-DPDK_VERSION=${1:-18.11.6}
+DPDK_VERSION=${1:-18.11.7}
 DPDK_PATH=${2:-http://fast.dpdk.org/rel}
 DPDK_TARGET=/usr/local/src/dpdk-stable-${DPDK_VERSION}
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -33,6 +33,7 @@ sudo apt-get update \
     linux-headers-$(uname -r) \
     llvm-dev \
     pkg-config \
+    python-pyelftools \
     python3-setuptools \
     python3-pip \
     wget \


### PR DESCRIPTION
- update readme accordingly
- install python-pyelftools for use w/ dpdk-pmdinfo.py

once merged: 
- [x] update https://github.com/capsule-rs/capsule README quickstart
- [x] push dpdk-mod to hub.docker.com