### PR TITLE
move to rust 1.49 + dpdk 19.11.6 (LTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ The Capsule sandbox is a containerized development environment for building [Cap
 
 ## Table of Contents
 
-* [Introduction](#introduction)
-* [Getting Started](#getting-started)
-  * [Vagrant and Docker](#vagrant-and-docker)
-  * [Linux Distributions](#linux-distributions)
-  * [Without Docker](#without-docker)
-  * [Kernel NIC Interface](#kernel-nic-interface)
-* [Packaging for Release](#packaging-for-release)
-* [Contributing](#contributing)
-* [Code of Conduct](#code-of-conduct)
-* [Contact](#contact)
-* [License](#license)
+- [Introduction](#introduction)
+- [Getting Started](#getting-started)
+  - [Vagrant and Docker](#vagrant-and-docker)
+  - [Linux Distributions](#linux-distributions)
+  - [Without Docker](#without-docker)
+  - [Kernel NIC Interface](#kernel-nic-interface)
+- [Packaging for Release](#packaging-for-release)
+- [Contributing](#contributing)
+- [Code of Conduct](#code-of-conduct)
+- [Contact](#contact)
+- [License](#license)
 
 ## Introduction
 
@@ -66,7 +66,7 @@ vagrant$ docker run -it --rm \
     --security-opt seccomp=unconfined \
     -v /lib/modules:/lib/modules \
     -v /dev/hugepages:/dev/hugepages \
-    getcapsule/sandbox:19.11.1-1.43 /bin/bash
+    getcapsule/sandbox:19.11.6-1.49 /bin/bash
 ```
 
 The sandbox must run in privileged mode with host networking, so it can access the two network interfaces on the Vagrant host dedicated to DPDK applications.
@@ -116,17 +116,17 @@ host$ exit
 Before your `Capsule` application can access a network interface on the host, the interface must be bound to a DPDK compatible driver with the [`dpdk-devbind`](https://doc.dpdk.org/guides/tools/devbind.html) utility. To bind the driver, find the interface's PCI address and use the command,
 
 ```
-host$ docker pull getcapsule/dpdk-devbind:19.11.1
+host$ docker pull getcapsule/dpdk-devbind:19.11.6
 host$ docker run --rm --privileged --network=host \
     -v /lib/modules:/lib/modules \
-    getcapsule/dpdk-devbind:19.11.1 \
+    getcapsule/dpdk-devbind:19.11.6 \
     /bin/bash -c 'dpdk-devbind.py --force -b uio_pci_generic #PCI_ADDR#'
 ```
 
 Once the necessary changes are made, pull down the sandbox container and run it,
 
 ```
-host$ docker pull getcapsule/sandbox:19.11.1-1.43
+host$ docker pull getcapsule/sandbox:19.11.6-1.49
 host$ docker run ...
 ```
 
@@ -168,7 +168,7 @@ host$ sudo insmod /lib/modules/`uname -r`/extra/dpdk/rte_kni.ko
 
 When packaging your application for release, the package must include the shared `DPDK` libraries and have as dependencies `libnuma` and `libpcap` for your Linux distribution.
 
-If you want to containerize your release, you can use [`getcapsule/dpdk:19.11.1`](https://hub.docker.com/repository/docker/getcapsule/dpdk) as the base image which includes `libnuma`, `libpcap` and `DPDK`. For other packaging methods, you can find the `DPDK` libraries in `/usr/local/lib/x86_64-linux-gnu`.
+If you want to containerize your release, you can use [`getcapsule/dpdk:19.11.6`](https://hub.docker.com/repository/docker/getcapsule/dpdk) as the base image which includes `libnuma`, `libpcap` and `DPDK`. For other packaging methods, you can find the `DPDK` libraries in `/usr/local/lib/x86_64-linux-gnu`.
 
 ## Contributing
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,9 +27,9 @@ VAGRANTFILE_API_VERSION = "2"
 end
 
 # Default Vagrant vars.
-$devbind_img = "getcapsule/dpdk-devbind:19.11.1"
-$dpdkmod_img = "getcapsule/dpdk-mod:19.11.1-`uname -r`"
-$sandbox_img = "getcapsule/sandbox:19.11.1-1.43"
+$devbind_img = "getcapsule/dpdk-devbind:19.11.6"
+$dpdkmod_img = "getcapsule/dpdk-mod:19.11.6-`uname -r`"
+$sandbox_img = "getcapsule/sandbox:19.11.6-1.49"
 
 $dpdk_driver = "uio_pci_generic"
 $dpdk_devices = "0000:00:08.0 0000:00:09.0"

--- a/docker.mk
+++ b/docker.mk
@@ -7,11 +7,11 @@ DPDK_DEVBIND_IMG = dpdk-devbind
 DPDK_MOD_IMG = dpdk-mod
 DPDK_MOD_KERNEL = $(shell uname -r)
 DPDK_TARGET = /usr/local/src/dpdk-$(DPDK_VERSION)
-DPDK_VERSION = 19.11.1
+DPDK_VERSION = 19.11.6
 
 RR_VERSION = 5.3.0
 RUST_BASE_IMG = rust:$(RUST_VERSION)-slim-buster
-RUST_VERSION = 1.47
+RUST_VERSION = 1.49
 
 SANDBOX_IMG = sandbox
 SANDBOX = $(DOCKER_NAMESPACE)/$(SANDBOX_IMG):$(DPDK_VERSION)-$(RUST_VERSION)
@@ -111,7 +111,7 @@ run-sandbox:
 
 test-sandbox:
 	@if [ "$$(docker images -q $(SANDBOX))" = "" ]; then \
-	docker pull $(SANDBOX); \
+	docker pull $(SANDBOX_IMG); \
 	fi
 	@docker run --rm --privileged --network=host --name $(SANDBOX_IMG) \
 	-w /home/capsule \

--- a/scripts/dpdk.sh
+++ b/scripts/dpdk.sh
@@ -18,7 +18,7 @@
 #
 
 ## Version we recommend.
-DPDK_VERSION=${1:-19.11.1}
+DPDK_VERSION=${1:-19.11.6}
 DPDK_PATH=${2:-http://fast.dpdk.org/rel}
 DPDK_TARGET=/usr/local/src/dpdk-stable-${DPDK_VERSION}
 


### PR DESCRIPTION
Associated with https://github.com/capsule-rs/capsule/pull/120 as well. 

Images have been pushed up to hub.docker. 

- [ ] update submod once https://github.com/capsule-rs/capsule/pull/120 is reviewed/in. 
