### PR TITLE
small network tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ This VM has three additional private network interfaces defined on the same subn
 
 ```
 # Specific IPs. These is needed because DPDK takes over the NIC.
-config.vm.network "private_network", ip: "10.100.1.10"
-config.vm.network "private_network", ip: "10.100.1.11"
+config.vm.network "private_network", ip: "10.100.1.10", :mac => "020000FFFF00"
+config.vm.network "private_network", ip: "10.100.1.11", :mac => "020000FFFF01"
 
 # NIC on the same subnet as the two dedicated to DPDK.
-config.vm.network "private_network", ip: "10.100.1.255", :mac => "020000FFFFFF"
+config.vm.network "private_network", ip: "10.100.1.254", :mac => "020000FFFFFF"
 ```
 
 Once inside the `Debian` VM with `Docker` installed. The VM is already preconfigured for DPDK. To run the sandbox, use the command,

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ This VM has three additional private network interfaces defined on the same subn
 
 ```
 # Specific IPs. These is needed because DPDK takes over the NIC.
-config.vm.network "private_network", ip: "10.100.1.10", :mac => "020000FFFF00"
-config.vm.network "private_network", ip: "10.100.1.11", :mac => "020000FFFF01"
+config.vm.network "private_network", ip: "192.168.56.10", :mac => "0200C0A8380A"
+config.vm.network "private_network", ip: "192.168.56.11", :mac => "0200C0A8380B"
 
 # NIC on the same subnet as the two dedicated to DPDK.
-config.vm.network "private_network", ip: "10.100.1.254", :mac => "020000FFFFFF"
+config.vm.network "private_network", ip: "192.168.56.129", :mac => "0200C0A83881"
 ```
 
 Once inside the `Debian` VM with `Docker` installed. The VM is already preconfigured for DPDK. To run the sandbox, use the command,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,11 +49,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_x11 = true
 
   # Specific IPs. These is needed because DPDK takes over the NIC.
-  config.vm.network "private_network", ip: "10.100.1.10"
-  config.vm.network "private_network", ip: "10.100.1.11"
+  config.vm.network "private_network", ip: "10.100.1.10", :mac => "020000FFFF00"
+  config.vm.network "private_network", ip: "10.100.1.11", :mac => "020000FFFF01"
 
   # NIC on the same subnet as the two bound to DPDK.
-  config.vm.network "private_network", ip: "10.100.1.255", :mac => "020000FFFFFF"
+  config.vm.network "private_network", ip: "10.100.1.254", :mac => "020000FFFFFF"
 
   # Pull and run our image(s) in order to do the devbind and insmod for kni.
   config.vm.define "docker", primary: true do |docker|
@@ -94,7 +94,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                      --network=host).join(" "),
             restart: "no",
             daemonize: true,
-            cmd: "insmod /lib/modules/`uname -r`/extra/dpdk/rte_kni.ko"
+            cmd: "insmod /lib/modules/`uname -r`/extra/dpdk/rte_kni.ko carrier=on"
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,11 +49,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_x11 = true
 
   # Specific IPs. These is needed because DPDK takes over the NIC.
-  config.vm.network "private_network", ip: "10.100.1.10", :mac => "020000FFFF00"
-  config.vm.network "private_network", ip: "10.100.1.11", :mac => "020000FFFF01"
+  config.vm.network "private_network", ip: "192.168.56.10", :mac => "0200C0A8380A"
+  config.vm.network "private_network", ip: "192.168.56.11", :mac => "0200C0A8380B"
 
   # NIC on the same subnet as the two bound to DPDK.
-  config.vm.network "private_network", ip: "10.100.1.254", :mac => "020000FFFFFF"
+  config.vm.network "private_network", ip: "192.168.56.129", :mac => "0200C0A83881"
 
   # Pull and run our image(s) in order to do the devbind and insmod for kni.
   config.vm.define "docker", primary: true do |docker|


### PR DESCRIPTION
add static MAC addresses. also had to change the static ipv4 addresses as well because a new virtualbox constraint.

```
daniel.jin@ sandbox % vagrant up
Bringing machine 'docker' up with 'virtualbox' provider...
==> docker: Importing base box 'debian/contrib-buster64'...
==> docker: Matching MAC address for NAT networking...
==> docker: Setting the name of the VM: debian-buster-capsule-docker
==> docker: Fixed port collision for 22 => 2222. Now on port 2200.
==> docker: Clearing any previously set network interfaces...
The IP address configured for the host-only network is not within the
allowed ranges. Please update the address used to be within the allowed
ranges and run the command again.

  Address: 10.100.1.10
  Ranges: 192.168.56.0/21

Valid ranges can be modified in the /etc/vbox/networks.conf file. For
more information including valid format see:

  https://www.virtualbox.org/manual/ch06.html#network_hostonly
```